### PR TITLE
AST-37667 adding an ability to send the agent to the 'results' command

### DIFF
--- a/src/main/wrapper/CxWrapper.ts
+++ b/src/main/wrapper/CxWrapper.ts
@@ -205,8 +205,8 @@ export class CxWrapper {
         return exec.executeResultsCommandsFile(scanId, CxConstants.FORMAT_HTML, CxConstants.FORMAT_HTML_FILE, commands, this.config.pathToExecutable, fileName);
     }
 
-    async getResults(scanId: string, resultType: string, outputFileName: string, outputFilePath: string) {
-        const commands = this.resultsShow(scanId, resultType, outputFileName, outputFilePath)
+    async getResults(scanId: string, resultType: string, outputFileName: string, outputFilePath: string, agent?: string | null) {
+        const commands = this.resultsShow(scanId, resultType, outputFileName, outputFilePath, agent)
         const exec = new ExecutionService();
         return await exec.executeCommands(this.config.pathToExecutable, commands);
     }
@@ -218,7 +218,7 @@ export class CxWrapper {
         return await exec.executeCommands(this.config.pathToExecutable, commands, CxConstants.CODE_BASHING_TYPE);
     }
 
-    resultsShow(scanId: string, reportFormat: string, outputFileName: string, outputPath: string): string[] {
+    resultsShow(scanId: string, reportFormat: string, outputFileName: string, outputPath: string, agent?: string | null): string[] {
         const commands: string[] = [CxConstants.CMD_RESULT, CxConstants.SUB_CMD_SHOW, CxConstants.SCAN_ID, scanId, CxConstants.REPORT_FORMAT, reportFormat];
         if (outputFileName) {
             commands.push(CxConstants.OUTPUT_NAME);
@@ -227,6 +227,10 @@ export class CxWrapper {
         if (outputPath) {
             commands.push(CxConstants.OUTPUT_PATH);
             commands.push(outputPath);
+        }
+        if (agent) {
+            commands.push(CxConstants.AGENT);
+            commands.push(agent);
         }
         commands.push(...this.initializeCommands(false));
         return commands;

--- a/src/tests/ResultTest.test.ts
+++ b/src/tests/ResultTest.test.ts
@@ -15,6 +15,16 @@ describe("Results cases",() => {
         });
     });
 
+    it('Result Test With Agent Flug Successful case', async () => {
+        const auth = new CxWrapper(cxScanConfig);
+        const cxCommandOutput: CxCommandOutput  = await auth.scanList("statuses=Completed");
+        const sampleId  = cxCommandOutput.payload.pop().id;
+        
+        auth.getResults(sampleId,"json","jsonList", ".", "jswrapper").then(() => {
+           fileExists("./jsonList.json").then(file => expect(file).toBe(true));
+        });
+    });
+
     it('Result List Successful case', async () => {
         const auth = new CxWrapper(cxScanConfig);
         const scanList: CxCommandOutput = await auth.scanList("statuses=Completed");


### PR DESCRIPTION
https://checkmarx.atlassian.net/browse/AST-37667

Adding an ability to send the agent to the 'results' command
Ast-cli using the agent to hide/show the container results