### PR TITLE
AST-43037 push version tag through PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
           npm ci
           npm run build
 
+      # CREATE PR FOR VERSION AND TAG CHANGES
       - name: Create Pull Request
         id: create_pr
         if: inputs.dev == false
@@ -103,7 +104,8 @@ jobs:
           body: "This is an automated PR created by GitHub Actions"
           base: main
           draft: false
-
+          
+      # WAIT FOR PR CREATION
       - name: Wait for PR to be created
         id: pr
         if: inputs.dev == false
@@ -111,6 +113,7 @@ jobs:
         with:
           route: GET /repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ env.BRANCH_NAME }}
 
+      # MERGE PR TO MAIN
       - name: Merge Pull Request
         if: inputs.dev == false
         uses: octokit/request-action@v2.3.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,8 @@ jobs:
         if: inputs.dev == false
         uses: peter-evans/create-pull-request@v6.0.5
         with:
-          token: $GITHUB_TOKEN
-          branch: $BRANCH_NAME
+          token: ${{ env.GITHUB_TOKEN }}
+          branch: ${{ env.BRANCH_NAME }}
           title: "Update Version - Automated Changes"
           body: "This is an automated PR created by GitHub Actions"
           base: main
@@ -109,7 +109,7 @@ jobs:
         if: inputs.dev == false
         uses: octokit/request-action@v2.3.1
         with:
-          route: GET /repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:$BRANCH_NAME
+          route: GET /repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ env.BRANCH_NAME }}
 
       - name: Merge Pull Request
         if: inputs.dev == false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
           GITHUB_TOKEN: ${{ secrets.OR_GITHUB_TOKEN }}
+          BRANCH_NAME: npm-version-patch
     steps:
 
       # CHECKOUT PROJECT
@@ -91,10 +92,31 @@ jobs:
           npm ci
           npm run build
 
-      # PUSH TAGS IF IT IS A RELEASE
-      - name: Push tag if release
+      - name: Create Pull Request
+        id: create_pr
         if: inputs.dev == false
-        run: git push && git push --tags
+        uses: peter-evans/create-pull-request@v6.0.5
+        with:
+          token: $GITHUB_TOKEN
+          branch: $BRANCH_NAME
+          title: "Update Version - Automated Changes"
+          body: "This is an automated PR created by GitHub Actions"
+          base: main
+          draft: false
+
+      - name: Wait for PR to be created
+        id: pr
+        if: inputs.dev == false
+        uses: octokit/request-action@v2.3.1
+        with:
+          route: GET /repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:$BRANCH_NAME
+
+      - name: Merge Pull Request
+        if: inputs.dev == false
+        uses: octokit/request-action@v2.3.1
+        with:
+          route: PUT /repos/${{ github.repository }}/pulls/${{ steps.create_pr.outputs.pull-request-number }}/merge
+          merge_method: squash
 
       # PUBLISH NPM PACKAGE
       - name: Publish npm package


### PR DESCRIPTION
https://checkmarx.atlassian.net/browse/AST-43037

fix the release.yml

Instead of pushing directly to the main branch, we now do the following steps:

- push the changes that become from the updating of the version in the package.json and package-lock.json to a new branch
- push the new tag also to the branch
- open a PR
- merge the PR to 'main' with the personal token (Or token)