### PR TITLE
security: harden all workflow files

### DIFF
--- a/.github/workflows/ast-cli-team-review.yml
+++ b/.github/workflows/ast-cli-team-review.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ github.event.pull_request.user.type != 'Bot' }}
     steps:
       - name: Set up GitHub CLI
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           version: latest
 
@@ -37,8 +37,9 @@ jobs:
         id: reviewers
         env:
           GH_TOKEN: ${{ secrets.AST_CLI_GH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr view ${{ github.event.pull_request.number }} --json reviewRequests --jq '.reviewRequests' > all_reviewers.json
+          gh pr view "$PR_NUMBER" --json reviewRequests --jq '.reviewRequests' > all_reviewers.json
 
           jq -r '.[] | select(.type == "User") | .login' all_reviewers.json > user_reviewers.txt
           jq -r '.[] | select(.type == "Team") | .login' all_reviewers.json > team_reviewers.txt

--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -2,19 +2,22 @@ name: Post-Check Actions
 on: [pull_request]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   dependabot-merge:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: cx-public-ubuntu-x64
     if: contains(github.head_ref, 'feature/update_cli')
     steps:
       - name: Enable auto-merge for Dependabot PRs
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.PERSONAL_ACCESS_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr merge --auto --squash "$PR_URL"
       - name: Auto approve dependabot PRs
         uses: step-security/auto-approve-action@0c28339628c8e79ab2f6813291e7e6cd584b4d30 # v4.0.0
         with:
-          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   integration-tests:
     runs-on: cx-public-ubuntu-x64
     steps:
-      - uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2   #v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
 
@@ -19,7 +19,7 @@ jobs:
           git lfs install
 
       - name: Use Node.js 22.11.0
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8     #v4.0.2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.11.0
           registry-url: https://npm.pkg.github.com/

--- a/.github/workflows/delete-packages-and-releases.yml
+++ b/.github/workflows/delete-packages-and-releases.yml
@@ -14,28 +14,30 @@ on:
         required: true
 
 permissions:
-  id-token: write
-  contents: write
-  packages: write
-
+  contents: read
 
 jobs:
   delete:
+    permissions:
+      contents: write
+      packages: write
     runs-on: cx-public-ubuntu-x64
     steps:
 
       - name: Delete npm packages
         continue-on-error: true
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "Deleting all npm packages whose name ends with '-${INPUT_TAG}.0'"
 
-          echo "Deleting all npm packages whose name ends with '-${{inputs.tag}}.0'"
-
-          VERSION_IDS=($(curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/Checkmarx/packages/npm/ast-cli-javascript-wrapper/versions | jq '.[]|select(.name | contains("-${{inputs.tag}}.0"))|.id'))
+          VERSION_IDS=($(curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/Checkmarx/packages/npm/ast-cli-javascript-wrapper/versions | jq ".[]|select(.name | contains(\"-${INPUT_TAG}.0\"))|.id"))
 
           for versionId in "${VERSION_IDS[@]}"
           do
              echo "Deleting version $versionId..."
-             curl -L -X DELETE -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/orgs/Checkmarx/packages/npm/ast-cli-javascript-wrapper/versions/$versionId"
+             curl -L -X DELETE -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/orgs/Checkmarx/packages/npm/ast-cli-javascript-wrapper/versions/$versionId"
              echo "Version $versionId deleted successfully!"
           done
 
@@ -43,8 +45,8 @@ jobs:
         continue-on-error: true
         uses: dev-drprasad/delete-older-releases@dfbe6be2a006e9475dfcbe5b8d201f1824c2a9fe #v0.3.4
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           keep_latest: 0
-          delete_tag_pattern: "-${{inputs.tag}}.0"
+          delete_tag_pattern: "-${{ inputs.tag }}.0"
           delete_tags: true

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,10 +2,13 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   dependabot-merge:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: cx-public-ubuntu-x64
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
@@ -13,13 +16,13 @@ jobs:
         id: metadata
         uses: step-security/dependabot-fetch-metadata@bf8fb6e0be0a711c669dc236de6e7f7374ba626e # v3.1.0
         with:
-          github-token: "${{ secrets.PERSONAL_ACCESS_TOKEN  }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.PERSONAL_ACCESS_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr merge --auto --squash "$PR_URL"
       - name: Auto approve dependabot PRs
         uses: step-security/auto-approve-action@0c28339628c8e79ab2f6813291e7e6cd584b4d30 # v4.0.0
         with:
-          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,7 @@
 name: Nightly Release
 
 permissions:
-  id-token: write
-  contents: write
-  packages: write
+  contents: read
 
 on:
   push:
@@ -12,5 +10,9 @@ on:
 
 jobs:
   nightly:
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
     uses: Checkmarx/ast-cli-javascript-wrapper/.github/workflows/release.yml@main
     secrets: inherit

--- a/.github/workflows/update-cli.yml
+++ b/.github/workflows/update-cli.yml
@@ -9,9 +9,11 @@ permissions:
 
 jobs:
   update-checkmarx-cli:
+    permissions:
+      contents: write
     runs-on: cx-public-ubuntu-x64
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
 
@@ -29,23 +31,23 @@ jobs:
       - name: Get Latest Checkmarx API version
         id: checkmarx-ast-cli
         run: |
-          echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/Checkmarx/ast-cli/releases/latest | jq -r ".tag_name")
-          echo ::set-output name=current_tag::$(<checkmarx-ast-cli.version)
+          echo "release_tag=$(curl -sL https://api.github.com/repos/Checkmarx/ast-cli/releases/latest | jq -r '.tag_name')" >> $GITHUB_OUTPUT
+          echo "current_tag=$(<checkmarx-ast-cli.version)" >> $GITHUB_OUTPUT
 
       - name: Update Checkmarx cli version
         if: steps.checkmarx-ast-cli.outputs.current_tag != steps.checkmarx-ast-cli.outputs.release_tag
         env:
           RELEASE_TAG: ${{ steps.checkmarx-ast-cli.outputs.release_tag }}
         run: |
-          # Update current release
-          echo ${{ steps.checkmarx-ast-cli.outputs.release_tag }} > checkmarx-ast-cli.version
+          echo "$RELEASE_TAG" > checkmarx-ast-cli.version
 
       - name: Download latest cli and update branch
         if: steps.checkmarx-ast-cli.outputs.current_tag != steps.checkmarx-ast-cli.outputs.release_tag
+        env:
+          RELEASE_TAG: ${{ steps.checkmarx-ast-cli.outputs.release_tag }}
         run: |
-          # Update binaries
           chmod +x ./.github/scripts/update_cli.sh
-          ./.github/scripts/update_cli.sh ${{ steps.checkmarx-ast-cli.outputs.release_tag }}
+          ./.github/scripts/update_cli.sh "$RELEASE_TAG"
 
       - name: Track large files with Git LFS
         if: steps.checkmarx-ast-cli.outputs.current_tag != steps.checkmarx-ast-cli.outputs.release_tag


### PR DESCRIPTION
## Summary

Fixes the startup failure (`id-token: write` permission mismatch) and hardens all remaining workflow files.

**Applied across all workflows:**
- Move permissions from workflow level to job level (least privilege)
- Replace `PERSONAL_ACCESS_TOKEN` with `GITHUB_TOKEN`
- Fix script injection by moving `inputs.*` and context expressions to `env` vars in `run` steps
- Update pinned action SHAs: `actions/checkout` v6.0.3, `actions/setup-node` v6.4.0
- Add `pull-requests: write` to `auto-merge-pr` and `dependabot-auto-merge` jobs
- Fix `${{ github.event.pull_request.number }}` injection in `ast-cli-team-review.yml`
- Replace deprecated `::set-output` with `$GITHUB_OUTPUT` in `update-cli.yml`