### PR TITLE
security: replace dev-drprasad/delete-older-releases with gh CLI

### DIFF
--- a/.github/workflows/delete-packages-and-releases.yml
+++ b/.github/workflows/delete-packages-and-releases.yml
@@ -43,10 +43,13 @@ jobs:
 
       - name: Delete releases and tags
         continue-on-error: true
-        uses: dev-drprasad/delete-older-releases@dfbe6be2a006e9475dfcbe5b8d201f1824c2a9fe #v0.3.4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          keep_latest: 0
-          delete_tag_pattern: "-${{ inputs.tag }}.0"
-          delete_tags: true
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          gh release list --limit 100 --json tagName \
+            --jq ".[] | select(.tagName | contains(\"-${INPUT_TAG}.0\")) | .tagName" \
+            | while IFS= read -r tag; do
+                echo "Deleting release and tag: $tag"
+                gh release delete "$tag" --yes --cleanup-tag || true
+              done


### PR DESCRIPTION
## Summary

- Replace `dev-drprasad/delete-older-releases` with equivalent `gh release delete --cleanup-tag` commands
- `gh` CLI is pre-installed on all GitHub-hosted runners — no external action needed